### PR TITLE
chore: drop master from CI branch filters

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -14,9 +14,9 @@ on:
         type: boolean
         default: false
   push:
-    branches: [ "main", "master" ]
+    branches: [ "main" ]
   pull_request:
-    branches: [ "main", "master" ]
+    branches: [ "main" ]
 
 jobs:
   ci:


### PR DESCRIPTION
Limpieza final del rename `master` → `main`.

El filtro dual `[ "main", "master" ]` existía solo para que no hubiera ventana sin CI durante el rename. La rama `master` ya no existe, así que se queda en `[ "main" ]`.

Los guards de `CD` y `Sync standards` no se tocan: ya usan `github.event.repository.default_branch` y son inmunes a futuros renames.

🤖 Generated with [Claude Code](https://claude.com/claude-code)