### PR TITLE
chore: consume the bindings toolbox and declare the upstream manifest

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -20,7 +20,7 @@ on:
 
 jobs:
   ci:
-    uses: EvergineTeam/evergine-standards/.github/workflows/binding-common-ci.yml@v2
+    uses: EvergineTeam/Evergine.Bindings/.github/workflows/binding-common-ci.yml@v1
     with:
       generator-project: "WebGPUGen/WebGPUGen/WebGPUGen.csproj"  # Path to your generator .csproj
       generator-name: "WebGPU"                # Name of your generator executable

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -17,7 +17,7 @@ on:
 jobs:
   publish:
     if: github.event_name != 'schedule' || github.ref_name == github.event.repository.default_branch
-    uses: EvergineTeam/evergine-standards/.github/workflows/binding-simple-cd.yml@v2
+    uses: EvergineTeam/Evergine.Bindings/.github/workflows/binding-simple-cd.yml@v1
     with:
       generator-project: "WebGPUGen/WebGPUGen/WebGPUGen.csproj"  # Path to your generator .csproj
       generator-name: "WebGPU"                # Name of your generator executable

--- a/binding.yml
+++ b/binding.yml
@@ -1,0 +1,38 @@
+# Binding manifest — see https://github.com/EvergineTeam/Evergine.Bindings
+# Schema: https://github.com/EvergineTeam/Evergine.Bindings/blob/main/binding.schema.json
+toolbox: 1.0.0
+
+package:
+  id: Evergine.Bindings.WebGPU
+  project: WebGPUGen/Evergine.Bindings.WebGPU/Evergine.Bindings.WebGPU.csproj
+  target-framework: net10.0
+  runtime-identifier: win-x64
+
+upstream:
+  kind: git-tree
+  language: c
+  project: https://github.com/emscripten-core/emscripten
+  version-from: git-release
+  sources:
+    - repo: emscripten-core/emscripten
+      ref: "3.1.56"
+      remote-path: system/include/webgpu/webgpu.h
+      path: WebGPUGen/WebGPUGen/Headers/webgpu.h
+      format: c-header
+
+generator:
+  project: WebGPUGen/WebGPUGen/WebGPUGen.csproj
+  name: WebGPU
+  output:
+    - WebGPUGen/Evergine.Bindings.WebGPU/Generated
+
+# NOTE — do not let an agent bump `ref` here without a human deciding.
+#
+# Since June 2025 this binding targets browsers only, because the .NET SDK is pinned to
+# a specific Emscripten version (the README cites 3.1.36 for .NET 10). The header ref
+# above is 3.1.56, which does not match that number. Whether that is intentional, stale
+# documentation, or a real mismatch needs a person to resolve -- it is exactly the kind
+# of question the manifest is meant to surface rather than answer.
+#
+# Until it is resolved, treat `ref` as frozen: binding-updater may report that a newer
+# Emscripten exists, but must not propose the bump.


### PR DESCRIPTION
Fase 2. Repunta CI y CD al toolbox `Evergine.Bindings@v1` y añade `binding.yml`.

## Evidencia acumulada de que es un no-op

Siete repos verificados hasta ahora comparando el `.nupkg` del pipeline viejo contra el nuevo. En todos: mismo conjunto de entradas, **tamaños idénticos**, y el ensamblado difiere solo en metadatos de build.

| Repo | Entradas | Bytes distintos |
|---|---|---|
| Vulkan.NET | 7 | 147 / 1.052.672 |
| OpenXR.NET | 7 | 147 / 671.232 |
| KTX.NET | 18 | 148 / 53.760 |
| xatlas.NET | 12 | 150 / 9.728 |
| Meshoptimizer.NET | 12 | 150 / 15.360 |
| JoltPhysics.NET | 17 | 150 / 119.296 |
| Cesium.NET | 48 | 150 / 50.176 |

Siempre ~150 bytes con independencia del tamaño del ensamblado, y siempre los mismos: `TimeDateStamp` del PE, MVID, checksum del PDB y el `InformationalVersion 1.0.0+<sha>`. Cero diferencias de código.

## Hallazgo al escribir el manifiesto

El header viene de Emscripten **3.1.56**, pero el README dice que el .NET SDK va acoplado a **3.1.36** para .NET 10. No lo resuelvo aquí: puede ser intencionado, documentación vieja o un desajuste real. El manifiesto deja `ref` congelado y lo documenta, que es lo que debe hacer — sacar la pregunta a la luz, no contestarla por su cuenta.

🤖 Generated with [Claude Code](https://claude.com/claude-code)