### PR TITLE
fix: declare the MIT licence the repository already carries

### DIFF
--- a/WebGPUGen/Evergine.Bindings.WebGPU/Evergine.Bindings.WebGPU.csproj
+++ b/WebGPUGen/Evergine.Bindings.WebGPU/Evergine.Bindings.WebGPU.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <Copyright>Copyright (c) Evergine 2026</Copyright>

--- a/WebGPUGen/Evergine.Bindings.WebGPU/Evergine.Bindings.WebGPU.csproj
+++ b/WebGPUGen/Evergine.Bindings.WebGPU/Evergine.Bindings.WebGPU.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <Copyright>Copyright (c) Evergine 2026</Copyright>
@@ -8,6 +8,7 @@
     <RepositoryUrl>https://github.com/EvergineTeam/WebGPU.NET</RepositoryUrl>
     <PackageTags>WebGPU;Evergine;C#;DirectX;OpenGL;OpenGLES;Vulkan;Metal;2D;3D;AR;VR;MixedReality;Mobile</PackageTags>
     <PackageIcon>icon.png</PackageIcon>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
 	<PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>
 


### PR DESCRIPTION
Every push to nuget.org warns `License missing` and the published package carries no licence expression, so nuget.org shows nothing where the licence link belongs and a compliance scanner has nothing to read. The repository has shipped an MIT `LICENSE` all along.

One of eight: the same line was missing from every published `Evergine.Bindings` package. Each repository's own `LICENSE` was read and confirmed MIT before writing it here, rather than assumed.

Verified on Cesium.NET by packing locally, where the nuspec then carried `<license type="expression">MIT</license>`.